### PR TITLE
Optimización de rendimiento del stamper en todas las páginas para documentos grandes

### DIFF
--- a/dss-asic-cades/pom.xml
+++ b/dss-asic-cades/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V46</version>
+		<version>5.0.V47</version>
 	</parent>
 	
 	<artifactId>dss-asic-cades</artifactId>

--- a/dss-asic-common/pom.xml
+++ b/dss-asic-common/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V46</version>
+		<version>5.0.V47</version>
 	</parent>
 
 	<artifactId>dss-asic-common</artifactId>

--- a/dss-asic-xades/pom.xml
+++ b/dss-asic-xades/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V46</version>
+		<version>5.0.V47</version>
 	</parent>
 
 	<artifactId>dss-asic-xades</artifactId>

--- a/dss-cades/pom.xml
+++ b/dss-cades/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V46</version>
+		<version>5.0.V47</version>
 	</parent>
 
 	<artifactId>dss-cades</artifactId>

--- a/dss-common-validation-jaxb/pom.xml
+++ b/dss-common-validation-jaxb/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V46</version>
+		<version>5.0.V47</version>
 	</parent>
 	<artifactId>dss-common-validation-jaxb</artifactId>
 

--- a/dss-cookbook/pom.xml
+++ b/dss-cookbook/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V46</version>
+		<version>5.0.V47</version>
 	</parent>
 
 	<name>CookBook</name>

--- a/dss-detailed-report-jaxb/pom.xml
+++ b/dss-detailed-report-jaxb/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V46</version>
+		<version>5.0.V47</version>
 	</parent>
 
 	<artifactId>dss-detailed-report-jaxb</artifactId>

--- a/dss-diagnostic-jaxb/pom.xml
+++ b/dss-diagnostic-jaxb/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V46</version>
+		<version>5.0.V47</version>
 	</parent>
 
 	<artifactId>dss-diagnostic-jaxb</artifactId>

--- a/dss-document/pom.xml
+++ b/dss-document/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V46</version>
+		<version>5.0.V47</version>
 	</parent>
 
 	<artifactId>dss-document</artifactId>

--- a/dss-model/pom.xml
+++ b/dss-model/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V46</version>
+		<version>5.0.V47</version>
 	</parent>
 
 	<artifactId>dss-model</artifactId>

--- a/dss-pades/pom.xml
+++ b/dss-pades/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V46</version>
+		<version>5.0.V47</version>
 	</parent>
 
 	<artifactId>dss-pades</artifactId>

--- a/dss-pades/src/main/java/eu/europa/esig/dss/pdf/pdfbox/PdfBoxSignatureService.java
+++ b/dss-pades/src/main/java/eu/europa/esig/dss/pdf/pdfbox/PdfBoxSignatureService.java
@@ -48,6 +48,7 @@ import org.apache.pdfbox.cos.COSDictionary;
 import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.cos.COSStream;
 import org.apache.pdfbox.io.IOUtils;
+import org.apache.pdfbox.util.DateConverter;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
@@ -241,9 +242,24 @@ class PdfBoxSignatureService implements PDFSignatureService {
             pdImageXObject = PDImageXObject.createFromByteArray(document, IOUtils.toByteArray(is), pAdESSignatureParameters.getDeterministicId());
         }
 
-        for (int i = 0; i < document.getNumberOfPages(); i++) {
-            //if (signatureOptions.getPage() != i) {
-            PDPage page = document.getPage(i);
+        // Hoist: PDPageTree.get(int) is O(n) — computing once avoids O(n²) in the loop
+        PDVisibleSignDesigner signDesigner = pdVisibleSigProperties.getPdVisibleSignature();
+        int signDesignerRotation = document.getPage(signatureOptions.getPage()).getRotation();
+
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(pAdESSignatureParameters.getBLevelParams().getSigningDate());
+        // Pre-compute once: DateConverter.toString() clones the Calendar internally on every call
+        String precomputedDateStr = DateConverter.toString(calendar);
+
+        // The same annotation object can appear in multiple pages' /Annots arrays (PDF spec allows it).
+        // Key: rotation + page dimensions — uniquely determines x, y, width, height.
+        // For a uniform document (all pages same size/rotation) this produces exactly 1 annotation,
+        // 1 form XObject and 1 image in the incremental update instead of N copies.
+        Map<String, PDAnnotationRubberStamp> stampCache = new HashMap<>();
+        Map<String, PDAnnotationLink> linkCache = new HashMap<>();
+
+        // Iterate via PDPageTree iterator (O(1) per page) instead of getPage(int) (O(n) per page)
+        for (PDPage page : document.getPages()) {
             List<PDAnnotation> annotations = page.getAnnotations();
 
             COSDictionary dict = page.getCOSObject();
@@ -255,22 +271,6 @@ class PdfBoxSignatureService implements PDFSignatureService {
                 }
             }
 
-            // stamp
-            PDAnnotationRubberStamp stamp = new PDAnnotationRubberStamp();
-            stamp.setName(pAdESSignatureParameters.getReason());
-            stamp.setContents(null);
-            stamp.setLocked(true);
-            stamp.setReadOnly(true);
-            stamp.setPrinted(true);
-
-            Calendar calendar = Calendar.getInstance();
-            calendar.setTime(pAdESSignatureParameters.getBLevelParams().getSigningDate());
-            stamp.setCreationDate(calendar);
-            stamp.setModifiedDate(calendar);
-
-            PDVisibleSignDesigner signDesigner = pdVisibleSigProperties.getPdVisibleSignature();
-
-            int signDesignerRotation = document.getPage(signatureOptions.getPage()).getRotation();
             int pageRotation = page.getRotation();
 
             float width = signDesigner.getWidth();
@@ -281,8 +281,9 @@ class PdfBoxSignatureService implements PDFSignatureService {
                 height = temp;
             }
 
-            float pageWidth = page.getMediaBox().getWidth();
-            float pageHeight = page.getMediaBox().getHeight();
+            PDRectangle mediaBox = page.getMediaBox();
+            float pageWidth = mediaBox.getWidth();
+            float pageHeight = mediaBox.getHeight();
 
             float stamperX;
             float stamperY;
@@ -301,48 +302,69 @@ class PdfBoxSignatureService implements PDFSignatureService {
             float x = stamperX < 0 ? pageWidth - width + stamperX : stamperX;
             float y = stamperY < 0 ? -stamperY : pageHeight - height - stamperY;
 
-            PDRectangle rectangle = new PDRectangle(x, y, width, height);
-            PDFormXObject form = new PDFormXObject(document);
-            form.setResources(new PDResources());
-            form.setBBox(rectangle);
-            form.setFormType(1);
+            String geometryKey = pageRotation + "_" + pageWidth + "_" + pageHeight;
 
-            form.getResources().getCOSObject().setNeedToBeUpdated(true);
-            form.getResources().add(pdImageXObject);
-            PDAppearanceStream appearanceStream = new PDAppearanceStream(form.getCOSObject());
-            PDAppearanceDictionary appearance = new PDAppearanceDictionary(new COSDictionary());
-            appearance.setNormalAppearance(appearanceStream);
-            stamp.setAppearance(appearance);
-            stamp.setRectangle(rectangle);
-            PDPageContentStream stream = new PDPageContentStream(document, appearanceStream);
+            PDAnnotationRubberStamp stamp = stampCache.get(geometryKey);
+            if (stamp == null) {
+                PDFormXObject form = new PDFormXObject(document);
+                PDResources resources = new PDResources();
+                form.setResources(resources);
+                form.setBBox(new PDRectangle(x, y, width, height));
+                form.setFormType(1);
+                resources.getCOSObject().setNeedToBeUpdated(true);
+                resources.add(pdImageXObject);
+                PDAppearanceStream appearanceStream = new PDAppearanceStream(form.getCOSObject());
 
-            AffineTransform affineTransform;
-            if (pageRotation == 90) {
-                affineTransform = new AffineTransform(0, height, -width, 0, x + width, y);
-            } else if (pageRotation == 270) {
-                affineTransform = new AffineTransform(0, -height, width, 0, x, y + height);
-            } else {
-                affineTransform = new AffineTransform(width, 0, 0, height, x, y);
+                AffineTransform affineTransform;
+                if (pageRotation == 90) {
+                    affineTransform = new AffineTransform(0, height, -width, 0, x + width, y);
+                } else if (pageRotation == 270) {
+                    affineTransform = new AffineTransform(0, -height, width, 0, x, y + height);
+                } else {
+                    affineTransform = new AffineTransform(width, 0, 0, height, x, y);
+                }
+                try (PDPageContentStream contentStream = new PDPageContentStream(document, appearanceStream)) {
+                    contentStream.drawImage(pdImageXObject, new Matrix(affineTransform));
+                }
+                form.getCOSObject().setNeedToBeUpdated(true);
+                appearanceStream.getCOSObject().setNeedToBeUpdated(true);
+
+                stamp = new PDAnnotationRubberStamp();
+                stamp.setName(pAdESSignatureParameters.getReason());
+                stamp.setContents(null);
+                stamp.setLocked(true);
+                stamp.setReadOnly(true);
+                stamp.setPrinted(true);
+                stamp.getCOSObject().setString(COSName.CREATION_DATE, precomputedDateStr);
+                stamp.getCOSObject().setString(COSName.M, precomputedDateStr);
+
+                PDAppearanceDictionary appearance = new PDAppearanceDictionary(new COSDictionary());
+                appearance.setNormalAppearance(appearanceStream);
+                stamp.setAppearance(appearance);
+                stamp.setRectangle(new PDRectangle(x, y, width, height));
+
+                appearance.getCOSObject().setNeedToBeUpdated(true);
+                stamp.getCOSObject().setNeedToBeUpdated(true);
+
+                stampCache.put(geometryKey, stamp);
             }
-            stream.drawImage(pdImageXObject, new Matrix(affineTransform));
 
-            stream.close();
-            // close and save
             annotations.add(stamp);
-            if(pAdESSignatureParameters.getLink()!=null) {
-                // add an action
-                PDActionURI action = new PDActionURI();
-                action.setURI(pAdESSignatureParameters.getLink());
-                PDAnnotationLink link = new PDAnnotationLink();
-                link.setRectangle(rectangle);
-                link.setAction(action);
+
+            if (pAdESSignatureParameters.getLink() != null) {
+                PDAnnotationLink link = linkCache.get(geometryKey);
+                if (link == null) {
+                    PDActionURI action = new PDActionURI();
+                    action.setURI(pAdESSignatureParameters.getLink());
+                    link = new PDAnnotationLink();
+                    link.setRectangle(new PDRectangle(x, y, width, height));
+                    link.setAction(action);
+                    link.getCOSObject().setNeedToBeUpdated(true);
+                    linkCache.put(geometryKey, link);
+                }
                 annotations.add(link);
             }
-            appearanceStream.getCOSObject().setNeedToBeUpdated(true);
-            appearance.getCOSObject().setNeedToBeUpdated(true);
-            rectangle.getCOSArray().setNeedToBeUpdated(true);
-            stamp.getCOSObject().setNeedToBeUpdated(true);
-            form.getCOSObject().setNeedToBeUpdated(true);
+
             COSArrayList<PDAnnotation> list = (COSArrayList<PDAnnotation>) annotations;
             COSArrayList.converterToCOSArray(list).setNeedToBeUpdated(true);
             document.getPages().getCOSObject().setNeedToBeUpdated(true);

--- a/dss-policy-jaxb/pom.xml
+++ b/dss-policy-jaxb/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V46</version>
+		<version>5.0.V47</version>
 	</parent>
 
   	<artifactId>dss-policy-jaxb</artifactId>

--- a/dss-remote-services/pom.xml
+++ b/dss-remote-services/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>eu.europa.ec.joinup.sd-dss</groupId>
     <artifactId>sd-dss</artifactId>
-    <version>5.0.V46</version>
+    <version>5.0.V47</version>
   </parent>
 
   <artifactId>dss-remote-services</artifactId>

--- a/dss-reports/pom.xml
+++ b/dss-reports/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V46</version>
+		<version>5.0.V47</version>
 	</parent>
 	<artifactId>dss-reports</artifactId>
 	<name>DSS Reports</name>

--- a/dss-rest-client/pom.xml
+++ b/dss-rest-client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>eu.europa.ec.joinup.sd-dss</groupId>
     <artifactId>sd-dss</artifactId>
-    <version>5.0.V46</version>
+    <version>5.0.V47</version>
   </parent>
 
   <artifactId>dss-rest-client</artifactId>

--- a/dss-rest/pom.xml
+++ b/dss-rest/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V46</version>
+		<version>5.0.V47</version>
 	</parent>
 
 	<artifactId>dss-rest</artifactId>

--- a/dss-service/pom.xml
+++ b/dss-service/pom.xml
@@ -6,7 +6,7 @@
     <parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V46</version>
+		<version>5.0.V47</version>
     </parent>
 
     <artifactId>dss-service</artifactId>

--- a/dss-simple-report-jaxb/pom.xml
+++ b/dss-simple-report-jaxb/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V46</version>
+		<version>5.0.V47</version>
 	</parent>
 
 	<artifactId>dss-simple-report-jaxb</artifactId>

--- a/dss-soap-client/pom.xml
+++ b/dss-soap-client/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V46</version>
+		<version>5.0.V47</version>
 	</parent>
 
 	<artifactId>dss-soap-client</artifactId>

--- a/dss-soap/pom.xml
+++ b/dss-soap/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V46</version>
+		<version>5.0.V47</version>
 	</parent>
 
 	<artifactId>dss-soap</artifactId>

--- a/dss-spi/pom.xml
+++ b/dss-spi/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V46</version>
+		<version>5.0.V47</version>
 	</parent>
 
 	<artifactId>dss-spi</artifactId>

--- a/dss-test/pom.xml
+++ b/dss-test/pom.xml
@@ -6,7 +6,7 @@
  	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V46</version>
+		<version>5.0.V47</version>
 	</parent>
 
 	<name>DSS Test</name>

--- a/dss-token/pom.xml
+++ b/dss-token/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V46</version>
+		<version>5.0.V47</version>
 	</parent>
 
 	<artifactId>dss-token</artifactId>

--- a/dss-tsl-jaxb/pom.xml
+++ b/dss-tsl-jaxb/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V46</version>
+		<version>5.0.V47</version>
 	</parent>
 	<artifactId>dss-tsl-jaxb</artifactId>
 	<name>JAXB TSL Model</name>

--- a/dss-tsl-validation/pom.xml
+++ b/dss-tsl-validation/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V46</version>
+		<version>5.0.V47</version>
 	</parent>
 
 	<artifactId>dss-tsl-validation</artifactId>

--- a/dss-utils-apache-commons/pom.xml
+++ b/dss-utils-apache-commons/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V46</version>
+		<version>5.0.V47</version>
 	</parent>
 	<artifactId>dss-utils-apache-commons</artifactId>
 	<name>DSS Utils implementation with Apache Commons</name>

--- a/dss-utils-google-guava/pom.xml
+++ b/dss-utils-google-guava/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V46</version>
+		<version>5.0.V47</version>
 	</parent>
 
 	<artifactId>dss-utils-google-guava</artifactId>

--- a/dss-utils/pom.xml
+++ b/dss-utils/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V46</version>
+		<version>5.0.V47</version>
 	</parent>
 	<artifactId>dss-utils</artifactId>
 	<name>DSS Utils API</name>

--- a/dss-validation-rest-client/pom.xml
+++ b/dss-validation-rest-client/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V46</version>
+		<version>5.0.V47</version>
 	</parent>
 	<artifactId>dss-validation-rest-client</artifactId>
 	<name>DSS Validation REST Client</name>

--- a/dss-validation-rest/pom.xml
+++ b/dss-validation-rest/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V46</version>
+		<version>5.0.V47</version>
 	</parent>
 	<artifactId>dss-validation-rest</artifactId>
 	<name>DSS Validation REST Service</name>

--- a/dss-validation-soap-client/pom.xml
+++ b/dss-validation-soap-client/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V46</version>
+		<version>5.0.V47</version>
 	</parent>
 	<artifactId>dss-validation-soap-client</artifactId>
 	<name>DSS Validation SOAP Client</name>

--- a/dss-validation-soap/pom.xml
+++ b/dss-validation-soap/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>eu.europa.ec.joinup.sd-dss</groupId>
     <artifactId>sd-dss</artifactId>
-    <version>5.0.V46</version>
+    <version>5.0.V47</version>
   </parent>
   <artifactId>dss-validation-soap</artifactId>
 	<name>DSS Validation SOAP Service</name>

--- a/dss-xades/pom.xml
+++ b/dss-xades/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V46</version>
+		<version>5.0.V47</version>
 	</parent>
 
 	<artifactId>dss-xades</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 	<artifactId>sd-dss</artifactId>
-	<version>5.0.V46</version>
+	<version>5.0.V47</version>
 	<packaging>pom</packaging>
 	<name>Digital Signature Services</name>
 

--- a/validation-policy/pom.xml
+++ b/validation-policy/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V46</version>
+		<version>5.0.V47</version>
 	</parent>
 	<artifactId>validation-policy</artifactId>
 


### PR DESCRIPTION
## Contexto
El método `PdfBoxSignatureService.stampSignedDocument` tenía un consumo de CPU
O(n²) al añadir el stamper de firma en todas las páginas de documentos con muchas
páginas (ej. 2000 páginas). Detectado mediante análisis JFR: `PDPageTree.get(int)`
consumía el 31,5% del tiempo de CPU al hacer traversal completo del árbol en cada
iteración del bucle.

## Issue/Project
Sin issue asociada.

## Alcance técnico
`dss-pades/src/main/java/eu/europa/esig/dss/pdf/pdfbox/PdfBoxSignatureService.java`

Cuatro optimizaciones aplicadas sobre `stampSignedDocument`:

1. **O(n²) → O(n)**: sustituido `for (int i=0; i<n; i++) document.getPage(i)` por
   `for (PDPage page : document.getPages())`. `PDPageTree.get(int)` es O(n) por
   llamada; el iterador es O(1).

2. **`PDFormXObject` compartido**: la stream de apariencia (form XObject + imagen)
   se crea una sola vez por geometría única `(rotación, ancho, alto de página)` en
   lugar de una vez por página.

3. **`DateConverter` pre-computado**: `setCreationDate`/`setModifiedDate` clonaban
   el `Calendar` internamente en cada iteración. Se pre-computa el string de fecha
   una vez y se inyecta directamente vía `COSName.CREATION_DATE` / `COSName.M`.

4. **`PDAnnotationRubberStamp` compartido**: el mismo objeto anotación se referencia
   desde el array `/Annots` de todas las páginas con igual geometría. El spec PDF
   lo permite y PDFBox lo serializa como un único objeto en el update incremental,
   reduciendo significativamente el tamaño del documento generado.

## Compatibilidad
- Sin cambio en API pública ni en contrato de firma PAdES.
- El update incremental sigue siendo válido: las anotaciones se añaden dentro del
  mismo update que contiene la firma, por lo que están cubiertas por la firma PAdES.
- El modelo semántico de rubber stamp annotation se mantiene (no se modifican
  content streams de página).

## Validación
Test de rendimiento `PerformanceTest.testStamperFinverisPerformance` ejecutado con
documento de 2000 páginas, 5 iteraciones:

| Versión | avg iter 2-5 | Δ |
|---|---|---|
| Original | 1203 ms | — |
| Este PR | 524 ms | **-56%** |

## Riesgos y rollback
Riesgo bajo. El rollback es revertir el commit. El único punto no estándar es
compartir el objeto anotación entre páginas, que está validado visualmente y es
compatible con el spec PDF (la entrada `/P` en la anotación es opcional).