### PR TITLE
Actualización versión 5.0.V49 y corrección orden applyPreSaveFixes

### DIFF
--- a/dss-asic-cades/pom.xml
+++ b/dss-asic-cades/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V48</version>
+		<version>5.0.V49</version>
 	</parent>
 	
 	<artifactId>dss-asic-cades</artifactId>

--- a/dss-asic-common/pom.xml
+++ b/dss-asic-common/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V48</version>
+		<version>5.0.V49</version>
 	</parent>
 
 	<artifactId>dss-asic-common</artifactId>

--- a/dss-asic-xades/pom.xml
+++ b/dss-asic-xades/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V48</version>
+		<version>5.0.V49</version>
 	</parent>
 
 	<artifactId>dss-asic-xades</artifactId>

--- a/dss-cades/pom.xml
+++ b/dss-cades/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V48</version>
+		<version>5.0.V49</version>
 	</parent>
 
 	<artifactId>dss-cades</artifactId>

--- a/dss-common-validation-jaxb/pom.xml
+++ b/dss-common-validation-jaxb/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V48</version>
+		<version>5.0.V49</version>
 	</parent>
 	<artifactId>dss-common-validation-jaxb</artifactId>
 

--- a/dss-cookbook/pom.xml
+++ b/dss-cookbook/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V48</version>
+		<version>5.0.V49</version>
 	</parent>
 
 	<name>CookBook</name>

--- a/dss-detailed-report-jaxb/pom.xml
+++ b/dss-detailed-report-jaxb/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V48</version>
+		<version>5.0.V49</version>
 	</parent>
 
 	<artifactId>dss-detailed-report-jaxb</artifactId>

--- a/dss-diagnostic-jaxb/pom.xml
+++ b/dss-diagnostic-jaxb/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V48</version>
+		<version>5.0.V49</version>
 	</parent>
 
 	<artifactId>dss-diagnostic-jaxb</artifactId>

--- a/dss-document/pom.xml
+++ b/dss-document/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V48</version>
+		<version>5.0.V49</version>
 	</parent>
 
 	<artifactId>dss-document</artifactId>

--- a/dss-model/pom.xml
+++ b/dss-model/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V48</version>
+		<version>5.0.V49</version>
 	</parent>
 
 	<artifactId>dss-model</artifactId>

--- a/dss-pades/pom.xml
+++ b/dss-pades/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V48</version>
+		<version>5.0.V49</version>
 	</parent>
 
 	<artifactId>dss-pades</artifactId>

--- a/dss-pades/src/main/java/eu/europa/esig/dss/pdf/pdfbox/PdfBoxSignatureService.java
+++ b/dss-pades/src/main/java/eu/europa/esig/dss/pdf/pdfbox/PdfBoxSignatureService.java
@@ -159,8 +159,11 @@ class PdfBoxSignatureService implements PDFSignatureService {
                 }
 
                 options.setPreferredSignatureSize(SignatureOptions.DEFAULT_SIGNATURE_SIZE * 10);
-
                 pdDocument.addSignature(pdSignature, options);
+
+                // Apply acroform and visual fixes BEFORE saveIncrementalForExternalSigning
+                // so they are included in the signed content
+                applyPreSaveFixes(pdDocument, pAdESSignatureParameters, options, pdVisibleSigProperties);
 
                 ExternalSigningSupport externalSigning = pdDocument.saveIncrementalForExternalSigning(fileOutputStream);
                 byte[] dataToSign = IOUtils.toByteArray(externalSigning.getContent());
@@ -170,7 +173,7 @@ class PdfBoxSignatureService implements PDFSignatureService {
 
                 digest.update(dataToSign);
 
-            }else{
+            } else {
 
                 // register signature dictionary and sign interface
                 SignatureInterface signatureInterface = new SignatureInterface() {
@@ -189,41 +192,12 @@ class PdfBoxSignatureService implements PDFSignatureService {
 
                 options.setPreferredSignatureSize(pAdESSignatureParameters.getSignatureSize());
                 pdDocument.addSignature(pdSignature, signatureInterface, options);
+
+                applyPreSaveFixes(pdDocument, pAdESSignatureParameters, options, pdVisibleSigProperties);
+
+                saveDocumentIncrementally(pAdESSignatureParameters, fileOutputStream, pdDocument);
             }
 
-            PDAcroForm acroForm = pdDocument.getDocumentCatalog().getAcroForm();
-
-            // FIX Viafirma
-            if (acroForm != null && acroForm.getNeedAppearances()) {
-                // PDFBOX-3738 NeedAppearances true results in visible signature
-                // becoming invisible
-                acroForm.getCOSObject().removeItem(COSName.NEED_APPEARANCES);
-            }
-
-//  Test same digital in all pages
-//            if (pAdESSignatureParameters.getImageParameters() != null && pAdESSignatureParameters.getImageParameters().isInAllPages() && pdVisibleSigProperties != null && pdDocument.getNumberOfPages() > 1) {
-//                ImageAndResolution ires = ImageUtils.create(pAdESSignatureParameters.getImageParameters());
-//                PDImageXObject pdImageXObject;
-//                try (InputStream is = ires.getInputStream()) {
-//                    pdImageXObject = PDImageXObject.createFromByteArray(pdDocument, IOUtils.toByteArray(is), pAdESSignatureParameters.getDeterministicId());
-//                }
-//
-//                for (PDPage pdPage : pdDocument.getPages()) {
-//                    PDRectangle rectangle = createSignatureRectangle(pdVisibleSigProperties, pAdESSignatureParameters.getImageParameters(), pdPage);
-//                    addImageOnlySignatureField(pdDocument, pdPage, rectangle, pdSignature, pdImageXObject);
-//                }
-//            }
-// END Test
-            if (pAdESSignatureParameters.getImageParameters() != null
-                    && pAdESSignatureParameters.getImageParameters().isInAllPages()
-                    && pdVisibleSigProperties != null
-                    && pdDocument.getNumberOfPages() > 1
-            ) {
-                stampSignedDocument(pdDocument, pAdESSignatureParameters, options, pdVisibleSigProperties, pAdESSignatureParameters.getImageParameters());
-            } else if(pAdESSignatureParameters.getImageParameters() != null && pAdESSignatureParameters.getLink()!=null && pdVisibleSigProperties != null){
-                addLink(pdDocument, pAdESSignatureParameters, options, pdVisibleSigProperties, pAdESSignatureParameters.getImageParameters());
-            }
-            saveDocumentIncrementally(pAdESSignatureParameters, fileOutputStream, pdDocument);
             digestValue = digest.digest();
             if (logger.isDebugEnabled()) {
                 logger.debug("Digest to be signed: {}", Base64.toBase64String(digestValue));
@@ -233,6 +207,26 @@ class PdfBoxSignatureService implements PDFSignatureService {
             throw new DSSException(e);
         } finally {
             Utils.closeQuietly(options.getVisualSignature());
+        }
+    }
+
+    // Applies acroform NeedAppearances fix and visual stamp/link before the document is saved.
+    // Must be called BEFORE saveIncrementalForExternalSigning or saveDocumentIncrementally.
+    private void applyPreSaveFixes(PDDocument pdDocument, PAdESSignatureParameters pAdESSignatureParameters,
+                                   SignatureOptions options, PDVisibleSigProperties pdVisibleSigProperties) throws IOException {
+        PDAcroForm acroForm = pdDocument.getDocumentCatalog().getAcroForm();
+        // PDFBOX-3738: NeedAppearances true results in visible signature becoming invisible
+        if (acroForm != null && acroForm.getNeedAppearances()) {
+            acroForm.getCOSObject().removeItem(COSName.NEED_APPEARANCES);
+        }
+
+        if (pAdESSignatureParameters.getImageParameters() != null
+                && pAdESSignatureParameters.getImageParameters().isInAllPages()
+                && pdVisibleSigProperties != null
+                && pdDocument.getNumberOfPages() > 1) {
+            stampSignedDocument(pdDocument, pAdESSignatureParameters, options, pdVisibleSigProperties, pAdESSignatureParameters.getImageParameters());
+        } else if (pAdESSignatureParameters.getImageParameters() != null && pAdESSignatureParameters.getLink() != null && pdVisibleSigProperties != null) {
+            addLink(pdDocument, pAdESSignatureParameters, options, pdVisibleSigProperties, pAdESSignatureParameters.getImageParameters());
         }
     }
 

--- a/dss-policy-jaxb/pom.xml
+++ b/dss-policy-jaxb/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V48</version>
+		<version>5.0.V49</version>
 	</parent>
 
   	<artifactId>dss-policy-jaxb</artifactId>

--- a/dss-remote-services/pom.xml
+++ b/dss-remote-services/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>eu.europa.ec.joinup.sd-dss</groupId>
     <artifactId>sd-dss</artifactId>
-    <version>5.0.V48</version>
+    <version>5.0.V49</version>
   </parent>
 
   <artifactId>dss-remote-services</artifactId>

--- a/dss-reports/pom.xml
+++ b/dss-reports/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V48</version>
+		<version>5.0.V49</version>
 	</parent>
 	<artifactId>dss-reports</artifactId>
 	<name>DSS Reports</name>

--- a/dss-rest-client/pom.xml
+++ b/dss-rest-client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>eu.europa.ec.joinup.sd-dss</groupId>
     <artifactId>sd-dss</artifactId>
-    <version>5.0.V48</version>
+    <version>5.0.V49</version>
   </parent>
 
   <artifactId>dss-rest-client</artifactId>

--- a/dss-rest/pom.xml
+++ b/dss-rest/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V48</version>
+		<version>5.0.V49</version>
 	</parent>
 
 	<artifactId>dss-rest</artifactId>

--- a/dss-service/pom.xml
+++ b/dss-service/pom.xml
@@ -6,7 +6,7 @@
     <parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V48</version>
+		<version>5.0.V49</version>
     </parent>
 
     <artifactId>dss-service</artifactId>

--- a/dss-simple-report-jaxb/pom.xml
+++ b/dss-simple-report-jaxb/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V48</version>
+		<version>5.0.V49</version>
 	</parent>
 
 	<artifactId>dss-simple-report-jaxb</artifactId>

--- a/dss-soap-client/pom.xml
+++ b/dss-soap-client/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V48</version>
+		<version>5.0.V49</version>
 	</parent>
 
 	<artifactId>dss-soap-client</artifactId>

--- a/dss-soap/pom.xml
+++ b/dss-soap/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V48</version>
+		<version>5.0.V49</version>
 	</parent>
 
 	<artifactId>dss-soap</artifactId>

--- a/dss-spi/pom.xml
+++ b/dss-spi/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V48</version>
+		<version>5.0.V49</version>
 	</parent>
 
 	<artifactId>dss-spi</artifactId>

--- a/dss-test/pom.xml
+++ b/dss-test/pom.xml
@@ -6,7 +6,7 @@
  	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V48</version>
+		<version>5.0.V49</version>
 	</parent>
 
 	<name>DSS Test</name>

--- a/dss-token/pom.xml
+++ b/dss-token/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V48</version>
+		<version>5.0.V49</version>
 	</parent>
 
 	<artifactId>dss-token</artifactId>

--- a/dss-tsl-jaxb/pom.xml
+++ b/dss-tsl-jaxb/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V48</version>
+		<version>5.0.V49</version>
 	</parent>
 	<artifactId>dss-tsl-jaxb</artifactId>
 	<name>JAXB TSL Model</name>

--- a/dss-tsl-validation/pom.xml
+++ b/dss-tsl-validation/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V48</version>
+		<version>5.0.V49</version>
 	</parent>
 
 	<artifactId>dss-tsl-validation</artifactId>

--- a/dss-utils-apache-commons/pom.xml
+++ b/dss-utils-apache-commons/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V48</version>
+		<version>5.0.V49</version>
 	</parent>
 	<artifactId>dss-utils-apache-commons</artifactId>
 	<name>DSS Utils implementation with Apache Commons</name>

--- a/dss-utils-google-guava/pom.xml
+++ b/dss-utils-google-guava/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V48</version>
+		<version>5.0.V49</version>
 	</parent>
 
 	<artifactId>dss-utils-google-guava</artifactId>

--- a/dss-utils/pom.xml
+++ b/dss-utils/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V48</version>
+		<version>5.0.V49</version>
 	</parent>
 	<artifactId>dss-utils</artifactId>
 	<name>DSS Utils API</name>

--- a/dss-validation-rest-client/pom.xml
+++ b/dss-validation-rest-client/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V48</version>
+		<version>5.0.V49</version>
 	</parent>
 	<artifactId>dss-validation-rest-client</artifactId>
 	<name>DSS Validation REST Client</name>

--- a/dss-validation-rest/pom.xml
+++ b/dss-validation-rest/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V48</version>
+		<version>5.0.V49</version>
 	</parent>
 	<artifactId>dss-validation-rest</artifactId>
 	<name>DSS Validation REST Service</name>

--- a/dss-validation-soap-client/pom.xml
+++ b/dss-validation-soap-client/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V48</version>
+		<version>5.0.V49</version>
 	</parent>
 	<artifactId>dss-validation-soap-client</artifactId>
 	<name>DSS Validation SOAP Client</name>

--- a/dss-validation-soap/pom.xml
+++ b/dss-validation-soap/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>eu.europa.ec.joinup.sd-dss</groupId>
     <artifactId>sd-dss</artifactId>
-    <version>5.0.V48</version>
+    <version>5.0.V49</version>
   </parent>
   <artifactId>dss-validation-soap</artifactId>
 	<name>DSS Validation SOAP Service</name>

--- a/dss-xades/pom.xml
+++ b/dss-xades/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V48</version>
+		<version>5.0.V49</version>
 	</parent>
 
 	<artifactId>dss-xades</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 	<artifactId>sd-dss</artifactId>
-	<version>5.0.V48</version>
+	<version>5.0.V49</version>
 	<packaging>pom</packaging>
 	<name>Digital Signature Services</name>
 

--- a/validation-policy/pom.xml
+++ b/validation-policy/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V48</version>
+		<version>5.0.V49</version>
 	</parent>
 	<artifactId>validation-policy</artifactId>
 


### PR DESCRIPTION
## Contexto
Bump de versión a 5.0.V49 y corrección de un bug de orden de operaciones en
PdfBoxSignatureService: los fixes de acroform y el sello visual se aplicaban
DESPUÉS del guardado incremental, por lo que quedaban fuera del contenido firmado.

## Issue/Project
Sin issue asociada.

## Alcance técnico
- `pom.xml` (raíz y 35 módulos): versión `5.0.V48` → `5.0.V49`
- `dss-pades/src/main/java/eu/europa/esig/dss/pdf/pdfbox/PdfBoxSignatureService.java`:
  - Extracción del método privado `applyPreSaveFixes` que agrupa el fix de
    `NeedAppearances` (PDFBOX-3738) + el sellado en todas las páginas + el enlace.
  - Llamada a `applyPreSaveFixes` ANTES de `saveIncrementalForExternalSigning` y
    ANTES de `saveDocumentIncrementally`, en ambos flujos de firma.

## Compatibilidad
- Sin cambios en API ni contratos REST.
- El comportamiento externo es el mismo; la diferencia es que el sello y los fixes
  quedan ahora dentro del contenido firmado en lugar de en el incremento posterior.
- Rollback: revertir el commit o hacer merge de la rama anterior `5.0.V48`.

## Validación
Revisión manual del diff. Sin tests automáticos nuevos (cambio de refactor interno).

## Riesgos y rollback
Riesgo bajo. El único riesgo funcional es que algún cliente dependa del comportamiento
anterior (fixes fuera del contenido firmado), lo cual era incorrecto por diseño.
Rollback: `git revert` del commit o vuelta a la tag `5.0.V48`.
