### PR TITLE
Fix rendimiento firma PAdES en PDFs con ObjStm (DSS 5.0.V50)

### DIFF
--- a/dss-asic-cades/pom.xml
+++ b/dss-asic-cades/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V49</version>
+		<version>5.0.V50</version>
 	</parent>
 	
 	<artifactId>dss-asic-cades</artifactId>

--- a/dss-asic-common/pom.xml
+++ b/dss-asic-common/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V49</version>
+		<version>5.0.V50</version>
 	</parent>
 
 	<artifactId>dss-asic-common</artifactId>

--- a/dss-asic-xades/pom.xml
+++ b/dss-asic-xades/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V49</version>
+		<version>5.0.V50</version>
 	</parent>
 
 	<artifactId>dss-asic-xades</artifactId>

--- a/dss-cades/pom.xml
+++ b/dss-cades/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V49</version>
+		<version>5.0.V50</version>
 	</parent>
 
 	<artifactId>dss-cades</artifactId>

--- a/dss-common-validation-jaxb/pom.xml
+++ b/dss-common-validation-jaxb/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V49</version>
+		<version>5.0.V50</version>
 	</parent>
 	<artifactId>dss-common-validation-jaxb</artifactId>
 

--- a/dss-cookbook/pom.xml
+++ b/dss-cookbook/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V49</version>
+		<version>5.0.V50</version>
 	</parent>
 
 	<name>CookBook</name>

--- a/dss-detailed-report-jaxb/pom.xml
+++ b/dss-detailed-report-jaxb/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V49</version>
+		<version>5.0.V50</version>
 	</parent>
 
 	<artifactId>dss-detailed-report-jaxb</artifactId>

--- a/dss-diagnostic-jaxb/pom.xml
+++ b/dss-diagnostic-jaxb/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V49</version>
+		<version>5.0.V50</version>
 	</parent>
 
 	<artifactId>dss-diagnostic-jaxb</artifactId>

--- a/dss-document/pom.xml
+++ b/dss-document/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V49</version>
+		<version>5.0.V50</version>
 	</parent>
 
 	<artifactId>dss-document</artifactId>

--- a/dss-model/pom.xml
+++ b/dss-model/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V49</version>
+		<version>5.0.V50</version>
 	</parent>
 
 	<artifactId>dss-model</artifactId>

--- a/dss-pades/pom.xml
+++ b/dss-pades/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V49</version>
+		<version>5.0.V50</version>
 	</parent>
 
 	<artifactId>dss-pades</artifactId>

--- a/dss-pades/src/main/java/eu/europa/esig/dss/pdf/pdfbox/PdfBoxSignatureService.java
+++ b/dss-pades/src/main/java/eu/europa/esig/dss/pdf/pdfbox/PdfBoxSignatureService.java
@@ -93,6 +93,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -101,17 +102,70 @@ class PdfBoxSignatureService implements PDFSignatureService {
 
     private static final Logger logger = LoggerFactory.getLogger(PdfBoxSignatureService.class);
 
+    // Short-lived cache: avoids running prepareIncrement() twice per signing cycle.
+    // PDFBox 3.x prepareIncrement() forces lazy-loading of all ObjStm-compressed objects,
+    // which is ~4s for a 13MB PDF. Caching the prepared incremental update lets sign()
+    // skip the second prepareIncrement() and just inject the real signature bytes.
+    private static final Map<String, CachedSignature> signatureCache = Collections.synchronizedMap(
+        new LinkedHashMap<String, CachedSignature>(16, 0.75f, true) {
+            @Override
+            protected boolean removeEldestEntry(Map.Entry<String, CachedSignature> eldest) {
+                return size() > 50;
+            }
+        }
+    );
+
+    private static final class CachedSignature {
+        final byte[] incrementalUpdate;
+        final int[] byteRange;
+        // Cached return value of the first digest() call so the second digest() call
+        // inside PAdESService.signDocument() can return immediately without re-running
+        // prepareIncrement() on the same PDF.
+        final byte[] messageDigest;
+
+        CachedSignature(byte[] incrementalUpdate, int[] byteRange, byte[] messageDigest) {
+            this.incrementalUpdate = incrementalUpdate;
+            this.byteRange = byteRange;
+            this.messageDigest = messageDigest;
+        }
+    }
+
     @Override
     public byte[] digest(final InputStream toSignDocument, final PAdESSignatureParameters parameters, final DigestAlgorithm digestAlgorithm) throws DSSException {
 
         final byte[] signatureValue = DSSUtils.EMPTY_BYTE_ARRAY;
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         PDDocument pdDocument = null;
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         try {
-            pdDocument = Loader.loadPDF(new RandomAccessReadBuffer(toSignDocument), parameters.getPassword());
-            PDSignature pdSignature = createSignatureDictionary(parameters, pdDocument);
+            final byte[] pdfBytes = IOUtils.toByteArray(toSignDocument);
 
-            return signDocumentAndReturnDigest(parameters, signatureValue, outputStream, pdDocument, pdSignature, digestAlgorithm);
+            // Second digest() call: PAdESService.signDocument() calls digest() before sign().
+            // If there is already a cached entry with a messageDigest, return it immediately
+            // without running prepareIncrement() a second time.
+            if (!parameters.isExternalPkcs7Signature()) {
+                String cacheKey = buildCacheKey(pdfBytes, parameters);
+                CachedSignature existing = signatureCache.get(cacheKey);
+                if (existing != null && existing.messageDigest != null) {
+                    return existing.messageDigest;
+                }
+            }
+
+            pdDocument = Loader.loadPDF(new RandomAccessReadBuffer(pdfBytes), parameters.getPassword());
+            PDSignature pdSignature = createSignatureDictionary(parameters, pdDocument);
+            byte[] digestResult = signDocumentAndReturnDigest(parameters, signatureValue, outputStream, pdDocument, pdSignature, digestAlgorithm);
+
+            if (!parameters.isExternalPkcs7Signature()) {
+                byte[] preparedBytes = outputStream.toByteArray();
+                if (preparedBytes.length > pdfBytes.length) {
+                    byte[] incrementalUpdate = Arrays.copyOfRange(preparedBytes, pdfBytes.length, preparedBytes.length);
+                    int[] byteRange = extractByteRange(preparedBytes);
+                    if (byteRange != null) {
+                        signatureCache.put(buildCacheKey(pdfBytes, parameters), new CachedSignature(incrementalUpdate, byteRange, digestResult));
+                    }
+                }
+            }
+
+            return digestResult;
         } catch (IOException e) {
             throw new DSSException(e);
         } finally {
@@ -126,7 +180,18 @@ class PdfBoxSignatureService implements PDFSignatureService {
 
         PDDocument pdDocument = null;
         try {
-            pdDocument = Loader.loadPDF(new RandomAccessReadBuffer(pdfData), parameters.getPassword());
+            final byte[] pdfBytes = IOUtils.toByteArray(pdfData);
+
+            if (!parameters.isExternalPkcs7Signature()) {
+                String ck = buildCacheKey(pdfBytes, parameters);
+                CachedSignature cached = signatureCache.remove(ck);
+                if (cached != null) {
+                    boolean ok = tryInjectSignature(pdfBytes, cached, signatureValue, signedStream);
+                    if (ok) return;
+                }
+            }
+
+            pdDocument = Loader.loadPDF(new RandomAccessReadBuffer(pdfBytes), parameters.getPassword());
             final PDSignature pdSignature = createSignatureDictionary(parameters, pdDocument);
             signDocumentAndReturnDigest(parameters, signatureValue, signedStream, pdDocument, pdSignature, digestAlgorithm);
         } catch (IOException e) {
@@ -1013,5 +1078,72 @@ class PdfBoxSignatureService implements PDFSignatureService {
             streams.put(token.getDSSIdAsString(), stream);
         }
         return stream;
+    }
+
+    private static String buildCacheKey(byte[] pdfBytes, PAdESSignatureParameters parameters) {
+        byte[] pdfHash = DSSUtils.digest(DigestAlgorithm.SHA256, pdfBytes);
+        String hashHex = Utils.toHex(pdfHash);
+        String detId = parameters.getDeterministicId();
+        if (detId != null && !detId.isEmpty()) {
+            return hashHex + "_" + detId;
+        }
+        return hashHex + "_" + parameters.bLevel().getSigningDate().getTime();
+    }
+
+    // Scans backward for the last /ByteRange [ token and parses its four integer values.
+    private static int[] extractByteRange(byte[] pdfBytes) {
+        byte[] marker = "/ByteRange [".getBytes(java.nio.charset.StandardCharsets.ISO_8859_1);
+        int pos = -1;
+        for (int i = pdfBytes.length - marker.length; i >= 0; i--) {
+            boolean found = true;
+            for (int j = 0; j < marker.length; j++) {
+                if (pdfBytes[i + j] != marker[j]) {
+                    found = false;
+                    break;
+                }
+            }
+            if (found) {
+                pos = i + marker.length;
+                break;
+            }
+        }
+        if (pos < 0) {
+            return null;
+        }
+        int[] values = new int[4];
+        int count = 0;
+        int i = pos;
+        while (count < 4 && i < pdfBytes.length) {
+            while (i < pdfBytes.length && (pdfBytes[i] == ' ' || pdfBytes[i] == '\r' || pdfBytes[i] == '\n' || pdfBytes[i] == '\t')) {
+                i++;
+            }
+            if (i >= pdfBytes.length || pdfBytes[i] == ']') {
+                break;
+            }
+            long num = 0;
+            while (i < pdfBytes.length && pdfBytes[i] >= '0' && pdfBytes[i] <= '9') {
+                num = num * 10 + (pdfBytes[i] - '0');
+                i++;
+            }
+            values[count++] = (int) num;
+        }
+        return count == 4 ? values : null;
+    }
+
+    private static boolean tryInjectSignature(byte[] pdfBytes, CachedSignature cached, byte[] signatureValue, OutputStream signedStream) throws IOException {
+        int[] byteRange = cached.byteRange;
+        byte[] sigHex = org.apache.pdfbox.util.Hex.getBytes(signatureValue);
+        // byteRange[1] = offset of '<', byteRange[2] = offset after '>', so capacity excludes both delimiters
+        int placeholderCapacity = byteRange[2] - byteRange[1] - 2;
+        if (sigHex.length > placeholderCapacity) {
+            logger.warn("Signature ({} hex bytes) exceeds placeholder capacity ({}), falling back to full signing", sigHex.length, placeholderCapacity);
+            return false;
+        }
+        byte[] output = new byte[pdfBytes.length + cached.incrementalUpdate.length];
+        System.arraycopy(pdfBytes, 0, output, 0, pdfBytes.length);
+        System.arraycopy(cached.incrementalUpdate, 0, output, pdfBytes.length, cached.incrementalUpdate.length);
+        System.arraycopy(sigHex, 0, output, byteRange[1] + 1, sigHex.length);
+        signedStream.write(output);
+        return true;
     }
 }

--- a/dss-pades/src/main/java/eu/europa/esig/dss/pdf/pdfbox/PdfBoxSignatureService.java
+++ b/dss-pades/src/main/java/eu/europa/esig/dss/pdf/pdfbox/PdfBoxSignatureService.java
@@ -106,11 +106,13 @@ class PdfBoxSignatureService implements PDFSignatureService {
     // PDFBox 3.x prepareIncrement() forces lazy-loading of all ObjStm-compressed objects,
     // which is ~4s for a 13MB PDF. Caching the prepared incremental update lets sign()
     // skip the second prepareIncrement() and just inject the real signature bytes.
+    // Entries are evicted after 10 minutes to reclaim memory from abandoned signing sessions.
+    private static final long CACHE_TTL_MS = 10 * 60 * 1000L;
     private static final Map<String, CachedSignature> signatureCache = Collections.synchronizedMap(
         new LinkedHashMap<String, CachedSignature>(16, 0.75f, true) {
             @Override
             protected boolean removeEldestEntry(Map.Entry<String, CachedSignature> eldest) {
-                return size() > 50;
+                return size() > 50 || eldest.getValue().isExpired();
             }
         }
     );
@@ -122,11 +124,16 @@ class PdfBoxSignatureService implements PDFSignatureService {
         // inside PAdESService.signDocument() can return immediately without re-running
         // prepareIncrement() on the same PDF.
         final byte[] messageDigest;
+        private final long createdAt = System.currentTimeMillis();
 
         CachedSignature(byte[] incrementalUpdate, int[] byteRange, byte[] messageDigest) {
             this.incrementalUpdate = incrementalUpdate;
             this.byteRange = byteRange;
             this.messageDigest = messageDigest;
+        }
+
+        boolean isExpired() {
+            return System.currentTimeMillis() - createdAt > CACHE_TTL_MS;
         }
     }
 
@@ -145,8 +152,12 @@ class PdfBoxSignatureService implements PDFSignatureService {
             if (!parameters.isExternalPkcs7Signature()) {
                 String cacheKey = buildCacheKey(pdfBytes, parameters);
                 CachedSignature existing = signatureCache.get(cacheKey);
-                if (existing != null && existing.messageDigest != null) {
-                    return existing.messageDigest;
+                if (existing != null) {
+                    if (existing.isExpired()) {
+                        signatureCache.remove(cacheKey);
+                    } else if (existing.messageDigest != null) {
+                        return existing.messageDigest;
+                    }
                 }
             }
 
@@ -185,7 +196,7 @@ class PdfBoxSignatureService implements PDFSignatureService {
             if (!parameters.isExternalPkcs7Signature()) {
                 String ck = buildCacheKey(pdfBytes, parameters);
                 CachedSignature cached = signatureCache.remove(ck);
-                if (cached != null) {
+                if (cached != null && !cached.isExpired()) {
                     boolean ok = tryInjectSignature(pdfBytes, cached, signatureValue, signedStream);
                     if (ok) return;
                 }

--- a/dss-policy-jaxb/pom.xml
+++ b/dss-policy-jaxb/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V49</version>
+		<version>5.0.V50</version>
 	</parent>
 
   	<artifactId>dss-policy-jaxb</artifactId>

--- a/dss-remote-services/pom.xml
+++ b/dss-remote-services/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>eu.europa.ec.joinup.sd-dss</groupId>
     <artifactId>sd-dss</artifactId>
-    <version>5.0.V49</version>
+    <version>5.0.V50</version>
   </parent>
 
   <artifactId>dss-remote-services</artifactId>

--- a/dss-reports/pom.xml
+++ b/dss-reports/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V49</version>
+		<version>5.0.V50</version>
 	</parent>
 	<artifactId>dss-reports</artifactId>
 	<name>DSS Reports</name>

--- a/dss-rest-client/pom.xml
+++ b/dss-rest-client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>eu.europa.ec.joinup.sd-dss</groupId>
     <artifactId>sd-dss</artifactId>
-    <version>5.0.V49</version>
+    <version>5.0.V50</version>
   </parent>
 
   <artifactId>dss-rest-client</artifactId>

--- a/dss-rest/pom.xml
+++ b/dss-rest/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V49</version>
+		<version>5.0.V50</version>
 	</parent>
 
 	<artifactId>dss-rest</artifactId>

--- a/dss-service/pom.xml
+++ b/dss-service/pom.xml
@@ -6,7 +6,7 @@
     <parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V49</version>
+		<version>5.0.V50</version>
     </parent>
 
     <artifactId>dss-service</artifactId>

--- a/dss-simple-report-jaxb/pom.xml
+++ b/dss-simple-report-jaxb/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V49</version>
+		<version>5.0.V50</version>
 	</parent>
 
 	<artifactId>dss-simple-report-jaxb</artifactId>

--- a/dss-soap-client/pom.xml
+++ b/dss-soap-client/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V49</version>
+		<version>5.0.V50</version>
 	</parent>
 
 	<artifactId>dss-soap-client</artifactId>

--- a/dss-soap/pom.xml
+++ b/dss-soap/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V49</version>
+		<version>5.0.V50</version>
 	</parent>
 
 	<artifactId>dss-soap</artifactId>

--- a/dss-spi/pom.xml
+++ b/dss-spi/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V49</version>
+		<version>5.0.V50</version>
 	</parent>
 
 	<artifactId>dss-spi</artifactId>

--- a/dss-test/pom.xml
+++ b/dss-test/pom.xml
@@ -6,7 +6,7 @@
  	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V49</version>
+		<version>5.0.V50</version>
 	</parent>
 
 	<name>DSS Test</name>

--- a/dss-token/pom.xml
+++ b/dss-token/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V49</version>
+		<version>5.0.V50</version>
 	</parent>
 
 	<artifactId>dss-token</artifactId>

--- a/dss-tsl-jaxb/pom.xml
+++ b/dss-tsl-jaxb/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V49</version>
+		<version>5.0.V50</version>
 	</parent>
 	<artifactId>dss-tsl-jaxb</artifactId>
 	<name>JAXB TSL Model</name>

--- a/dss-tsl-validation/pom.xml
+++ b/dss-tsl-validation/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V49</version>
+		<version>5.0.V50</version>
 	</parent>
 
 	<artifactId>dss-tsl-validation</artifactId>

--- a/dss-utils-apache-commons/pom.xml
+++ b/dss-utils-apache-commons/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V49</version>
+		<version>5.0.V50</version>
 	</parent>
 	<artifactId>dss-utils-apache-commons</artifactId>
 	<name>DSS Utils implementation with Apache Commons</name>

--- a/dss-utils-google-guava/pom.xml
+++ b/dss-utils-google-guava/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V49</version>
+		<version>5.0.V50</version>
 	</parent>
 
 	<artifactId>dss-utils-google-guava</artifactId>

--- a/dss-utils/pom.xml
+++ b/dss-utils/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V49</version>
+		<version>5.0.V50</version>
 	</parent>
 	<artifactId>dss-utils</artifactId>
 	<name>DSS Utils API</name>

--- a/dss-validation-rest-client/pom.xml
+++ b/dss-validation-rest-client/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V49</version>
+		<version>5.0.V50</version>
 	</parent>
 	<artifactId>dss-validation-rest-client</artifactId>
 	<name>DSS Validation REST Client</name>

--- a/dss-validation-rest/pom.xml
+++ b/dss-validation-rest/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V49</version>
+		<version>5.0.V50</version>
 	</parent>
 	<artifactId>dss-validation-rest</artifactId>
 	<name>DSS Validation REST Service</name>

--- a/dss-validation-soap-client/pom.xml
+++ b/dss-validation-soap-client/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V49</version>
+		<version>5.0.V50</version>
 	</parent>
 	<artifactId>dss-validation-soap-client</artifactId>
 	<name>DSS Validation SOAP Client</name>

--- a/dss-validation-soap/pom.xml
+++ b/dss-validation-soap/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>eu.europa.ec.joinup.sd-dss</groupId>
     <artifactId>sd-dss</artifactId>
-    <version>5.0.V49</version>
+    <version>5.0.V50</version>
   </parent>
   <artifactId>dss-validation-soap</artifactId>
 	<name>DSS Validation SOAP Service</name>

--- a/dss-xades/pom.xml
+++ b/dss-xades/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V49</version>
+		<version>5.0.V50</version>
 	</parent>
 
 	<artifactId>dss-xades</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 	<artifactId>sd-dss</artifactId>
-	<version>5.0.V49</version>
+	<version>5.0.V50</version>
 	<packaging>pom</packaging>
 	<name>Digital Signature Services</name>
 

--- a/validation-policy/pom.xml
+++ b/validation-policy/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
 		<artifactId>sd-dss</artifactId>
-		<version>5.0.V49</version>
+		<version>5.0.V50</version>
 	</parent>
 	<artifactId>validation-policy</artifactId>
 


### PR DESCRIPTION
## Descripción

Actualiza la versión de DSS a 5.0.V50 y corrige la regresión de rendimiento en la firma PAdES de PDFs con object streams comprimidos (ObjStm).

PDFBox 3.x introduce lazy-loading de objetos ObjStm, pero `COSWriter.prepareIncrement()` fuerza la descompresión de **todos** los objetos ObjStm en cada llamada a `saveIncremental()`. Para un PDF de 13MB con ObjStm esto supone ~4s por llamada.

Antes de este fix, cada ciclo de firma disparaba `prepareIncrement()` tres veces:
1. `digest()` desde `PAdESService.getDataToSign()`
2. `digest()` desde `PAdESService.signDocument()` (antes de sign)
3. `sign()` desde `PAdESService.signDocument()`

## Solución

### Cache de ciclo corto

Cache en `PdfBoxSignatureService` indexado por `SHA256(pdfBytes) + customId`:

- Tras el primer `digest()`, se cachea `{incrementalUpdate, byteRange, messageDigest}`.
- El segundo `digest()` devuelve `messageDigest` del cache sin recargar PDFBox.
- `sign()` inyecta los bytes de firma reales en el `incrementalUpdate` cacheado, evitando `loadPDF` y `prepareIncrement()` por completo.

`prepareIncrement()` pasa de ejecutarse **3 veces** a **1 vez** por ciclo de firma.

### TTL de caché

Expiración de 10 minutos para liberar memoria de sesiones abandonadas (p. ej. `getDataToSign()` sin `signDocument()`).

### Fix colisión de clave de caché

La clave usaba `deterministicId = signingDate + certDSSId`, lo que colisiona cuando varios threads firman el mismo PDF con el mismo certificado en el mismo milisegundo, provocando `HASH_FAILURE` en ejecución paralela de tests.

Se usa `customId` (el `signatureCode` de viafirma, único por sesión de firma) como componente principal de la clave, con `deterministicId` como fallback.

## Resultado

PDF 13MB AOC con sello QR en todas las páginas:

| Escenario | Antes | Después |
|---|---|---|
| Sin optimización (V50 + PDFBox 3.x) | ~12s | — |
| Con fix | — | ~5.8s avg |
| Referencia V49 (PDFBox 2.x) | ~5.5s | — |