### PR TITLE
Fix colisión de clave en caché de firma PAdES

### DIFF
--- a/dss-pades/src/main/java/eu/europa/esig/dss/pdf/pdfbox/PdfBoxSignatureService.java
+++ b/dss-pades/src/main/java/eu/europa/esig/dss/pdf/pdfbox/PdfBoxSignatureService.java
@@ -1094,6 +1094,12 @@ class PdfBoxSignatureService implements PDFSignatureService {
     private static String buildCacheKey(byte[] pdfBytes, PAdESSignatureParameters parameters) {
         byte[] pdfHash = DSSUtils.digest(DigestAlgorithm.SHA256, pdfBytes);
         String hashHex = Utils.toHex(pdfHash);
+        // Prefer customId (viafirma signatureCode — unique per session) to avoid collisions
+        // when the same PDF is signed concurrently with the same certificate.
+        String customId = parameters.getCustomId();
+        if (customId != null && !customId.isEmpty()) {
+            return hashHex + "_" + customId;
+        }
         String detId = parameters.getDeterministicId();
         if (detId != null && !detId.isEmpty()) {
             return hashHex + "_" + detId;


### PR DESCRIPTION
## Descripción

Corrige un fallo de `HASH_FAILURE` en ejecución paralela de tests de firma PAdES.

La clave de caché en `PdfBoxSignatureService` usaba `deterministicId = signingDate + certDSSId`, que colisiona cuando varios threads firman el mismo PDF con el mismo certificado en el mismo milisegundo. Esto provoca que una sesión sobreescriba el `incrementalUpdate` de otra, resultando en `HASH_FAILURE` al verificar la firma.

## Solución

Se usa `customId` (el `signatureCode` de viafirma, único por sesión de firma) como componente principal de la clave de caché, con `deterministicId` como fallback.